### PR TITLE
fix: airflow-fab workflow permissions

### DIFF
--- a/.github/workflows/release-image--airflow-fab-3-alpine.yaml
+++ b/.github/workflows/release-image--airflow-fab-3-alpine.yaml
@@ -7,6 +7,10 @@ on:
     paths:
       - images/airflow-fab/3/VERSION
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   call_workflow:
     uses: ./.github/workflows/_release-image.yaml


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->


## What does your PR do?

Fix airflow-fab image workflow permissions


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated