### PR TITLE
fix: image workflow permissions

### DIFF
--- a/.github/workflows/_release-image.yaml
+++ b/.github/workflows/_release-image.yaml
@@ -46,6 +46,8 @@ on:
 jobs:
   create_tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       TAG_NAME: ${{ steps.push-tag.outputs.TAG_NAME }}
       VERSION_SW_MAJOR: ${{ steps.read-version.outputs.VERSION_SW_MAJOR }}
@@ -121,6 +123,9 @@ jobs:
   build_and_push_image:
     needs: [ create_tag ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-image--airflow-fab-3.yaml
+++ b/.github/workflows/release-image--airflow-fab-3.yaml
@@ -1,15 +1,13 @@
 name: release image / airflow-fab-3-alpine
 
 on:
+  pull_request:
   push:
     branches:
       - main
     paths:
       - images/airflow-fab/3/VERSION
-
-permissions:
-  contents: read
-  packages: write
+      - .github/workflows/release-image--airflow-fab-3.yaml
 
 jobs:
   call_workflow:


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md -->

## What does your PR do?

Fix all image workflow permissions


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/airflow-helm/charts/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated