### PR TITLE
feat: add GitSync v4 support

### DIFF
--- a/charts/airflow/ci/git-sync-v3-compat-values.yaml
+++ b/charts/airflow/ci/git-sync-v3-compat-values.yaml
@@ -1,0 +1,51 @@
+# Test values for git-sync v3 backward compatibility
+# This file ensures v3 continues to work with the chart
+
+airflow:
+  image:
+    repository: apache/airflow
+    tag: 2.8.4
+
+  executor: KubernetesExecutor
+
+  config:
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+
+dags:
+  # Use git-sync v3 with traditional configuration
+  gitSync:
+    enabled: true
+    image:
+      tag: v3.6.9
+    repo: "https://github.com/apache/airflow.git"
+
+    # v3-style: Use branch and optionally revision (not ref)
+    branch: "2.8.4"
+
+    # v3-style: Use syncWait in seconds (not period)
+    syncWait: 30
+
+    # Shallow clone
+    depth: 1
+
+    # Path to DAGs within the repo
+    repoSubPath: "airflow/example_dags"
+
+scheduler:
+  replicas: 1
+
+web:
+  replicas: 1
+
+workers:
+  enabled: false
+
+flower:
+  enabled: false
+
+postgresql:
+  enabled: true
+
+redis:
+  enabled: false

--- a/charts/airflow/ci/git-sync-v4-values.yaml
+++ b/charts/airflow/ci/git-sync-v4-values.yaml
@@ -1,0 +1,61 @@
+# Test values for git-sync v4 with new features
+# This file tests git-sync v4-specific functionality
+
+airflow:
+  image:
+    repository: apache/airflow
+    tag: 3.1.0
+
+  executors: [KubernetesExecutor]
+
+  config:
+    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
+    AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "true"
+
+dags:
+  # Use git-sync v4 with new features
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "https://github.com/apache/airflow.git"
+
+    # v4-specific: Use unified ref instead of branch + revision
+    ref: "3.1.0"
+
+    # v4-specific: Use Go duration format for period
+    period: "30s"
+
+    # v4-specific: Use Go duration format for period
+    syncTimeout: "120s"
+
+    # Use shallow clone (v4 default)
+    depth: 1
+
+    # v4-specific: Enable group-writable permissions
+    groupWrite: true
+
+    # Path to DAGs within the repo
+    repoSubPath: "airflow-core/src/airflow/example_dags"
+
+scheduler:
+  replicas: 1
+
+apiServer:
+  replicas: 1
+
+dagProcessor:
+  enabled: true
+  replicas: 1
+
+workers:
+  enabled: false
+
+flower:
+  enabled: false
+
+postgresql:
+  enabled: true
+
+redis:
+  enabled: false

--- a/charts/airflow/docs/faq/dags/load-dag-definitions.md
+++ b/charts/airflow/docs/faq/dags/load-dag-definitions.md
@@ -8,13 +8,18 @@ To use your airflow cluster, you will need to make your DAG definitions (python 
 
 While there are many ways you can achieve this, we natively support the following methods.
 
-## Option 1 - Git-Sync Sidecar 
+## Option 1 - Git-Sync Sidecar
 
 You may store DAG definitions in a git repo and configure the chart to automatically sync a local copy this repo into each airflow Pod at a regular interval.
 
+> 🟨 __Note__ 🟨
+>
+> The chart supports both git-sync v3 and v4 with automatic version detection.
+> For git-sync v4 migration information, see the [git-sync v4 migration guide](../../guides/git-sync-v4-migration.md).
+
 > 🟦 __Tip__ 🟦
 >
-> The content of the git repo will be stored at `{dags.path}/repo/`, 
+> The content of the git repo will be stored at `{dags.path}/repo/`,
 > by default this will be `/opt/airflow/dags/repo/`.
 
 <details>

--- a/charts/airflow/docs/guides/git-sync-v4-migration.md
+++ b/charts/airflow/docs/guides/git-sync-v4-migration.md
@@ -1,0 +1,308 @@
+# Git-Sync v4 Migration Guide
+
+This guide covers migrating from git-sync v3 to v4 in the Airflow Helm Chart.
+
+## Overview
+
+Git-sync v4 introduces significant architectural improvements and breaking changes compared to v3. However, this chart maintains **backward compatibility** by detecting the git-sync version and automatically configuring the appropriate environment variables.
+
+## What Changed in v4?
+
+### Key Improvements
+
+1. **Better Performance**: v4 fetches only the specific commit SHA needed, transferring less data
+2. **Simplified Sync Loop**: Eliminates race conditions where symbolic refs could change between operations
+3. **Enhanced Security**: Latest base images with CVE fixes
+4. **Cleaner API**: More consistent flag naming and behavior
+
+### Breaking Changes
+
+| Aspect | v3 | v4 |
+|--------|----|----|
+| **Default Sync** | Full history | Single commit (depth=1) |
+| **Environment Prefix** | `GIT_SYNC_*` | `GITSYNC_*` (accepts both) |
+| **Branch/Revision** | Separate `--branch` and `--rev` flags | Unified `--ref` flag |
+| **Sync Period** | `--wait` (seconds) | `--period` (Go duration) |
+| **Permissions** | `--change-permissions` (deprecated) | `--group-write` |
+| **SSH Detection** | Explicit `--ssh` flag required | Auto-detected from repo URL |
+| **Root Directory** | `/tmp/git` | `/git` (chart uses `/dags`) |
+| **Logging** | Free-form text | Structured JSON |
+
+## Migration Strategies
+
+### Option 1: Automatic (Recommended)
+
+The chart **automatically detects** the git-sync version and configures appropriate environment variables. Simply update the image tag:
+
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0  # Update from v3.6.9
+    repo: "https://github.com/your-org/airflow-dags.git"
+    branch: main
+    revision: HEAD
+```
+
+**Result**: The chart continues using v3-compatible variables that v4 accepts.
+
+### Option 2: Opt-in to v4 Features
+
+To leverage v4-specific features, use the new values:
+
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "https://github.com/your-org/airflow-dags.git"
+
+    # v4-specific: Use unified ref instead of branch + revision
+    ref: "main"  # Can be branch, tag, or commit SHA
+
+    # v4-specific: Use Go duration format for period
+    period: "30s"  # Instead of syncWait: 30
+
+    # v4-change: Sync timeout now requires Go duration format
+    syncTimeout: "60s"
+
+    # v4-specific: Enable group-writable permissions
+    groupWrite: true
+
+    # v4-specific: Additional git config options
+    gitConfig: "http.postBuffer:524288000"
+```
+
+### Option 3: Stay on v3
+
+If you need to remain on v3, pin the version:
+
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v3.6.9  # Pin to v3
+    # Continue using existing v3 configuration
+```
+
+## New Values in v4
+
+### `dags.gitSync.ref`
+
+**Type**: `string`
+**Default**: `""`
+**v4 Only**: Yes
+
+Unified git reference (branch, tag, or commit SHA). When set, overrides both `branch` and `revision`.
+
+```yaml
+# Examples:
+ref: "main"                    # Branch
+ref: "v1.2.3"                  # Tag
+ref: "abc123def456..."         # Full commit SHA
+```
+
+### `dags.gitSync.period`
+
+**Type**: `string`
+**Default**: `""`
+**v4 Only**: Yes
+
+Sync period using Go duration format. When set, overrides `syncWait`.
+
+```yaml
+# Examples:
+period: "30s"    # 30 seconds
+period: "1m"     # 1 minute
+period: "90s"    # 90 seconds
+period: "100ms"  # 100 milliseconds
+```
+
+### `dags.gitSync.groupWrite`
+
+**Type**: `bool`
+**Default**: `false`
+**v4 Only**: Yes
+
+Make synced files group-writable. Replaces the deprecated `--change-permissions` flag from v3.
+
+```yaml
+groupWrite: true
+```
+
+### `dags.gitSync.gitConfig`
+
+**Type**: `string`
+**Default**: `""`
+**v4 Only**: Yes
+
+Additional git configuration options in `key:value` format (comma-separated).
+
+```yaml
+# Examples:
+gitConfig: "http.postBuffer:524288000"
+gitConfig: "http.postBuffer:524288000,core.compression:0"
+```
+
+## Validation
+
+The chart validates that v4-specific values are not used with v3 images. If you try:
+
+```yaml
+dags:
+  gitSync:
+    image:
+      tag: v3.6.9  # Using v3
+    ref: "main"    # ERROR: v4-only value
+```
+
+You'll receive a clear error message:
+
+```
+ERROR: git-sync v3 Configuration Error
+
+You have set `dags.gitSync.ref` but are using git-sync v3.6.9.
+
+The `ref` value is only supported in git-sync v4+.
+
+Please either:
+  1. Update to git-sync v4: dags.gitSync.image.tag=v4.5.0
+  2. Use v3 values: dags.gitSync.branch and dags.gitSync.revision
+```
+
+## Complete Examples
+
+### Example 1: Basic v4 Migration
+
+**Before (v3):**
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v3.6.9
+    repo: "https://github.com/apache/airflow.git"
+    branch: main
+    revision: HEAD
+    syncWait: 60
+    depth: 1
+```
+
+**After (v4 - Backward Compatible):**
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "https://github.com/apache/airflow.git"
+    branch: main      # Still works!
+    revision: HEAD    # Still works!
+    syncWait: 60      # Still works!
+    # v4-change: Sync timeout now requires Go duration format
+    syncTimeout: "60s"
+    depth: 1
+```
+
+**After (v4 - Using New Features):**
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "https://github.com/apache/airflow.git"
+    ref: "main"       # Unified ref
+    period: "1m"      # Go duration format
+    depth: 1
+    groupWrite: true  # v4 feature
+    # v4-change: Sync timeout now requires Go duration format
+    syncTimeout: "60s"
+```
+
+### Example 2: SSH with v4
+
+**Before (v3):**
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v3.6.9
+    repo: "git@github.com:your-org/dags.git"
+    branch: main
+    sshSecret: "airflow-git-ssh-secret"
+    sshKnownHosts: |
+      github.com ssh-rsa AAAAB3NzaC1yc2E...
+```
+
+**After (v4):**
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "git@github.com:your-org/dags.git"
+    ref: "main"  # Use v4 ref
+    # v4-change: Sync timeout now requires Go duration format
+    syncTimeout: "60s"
+    sshSecret: "airflow-git-ssh-secret"
+    sshKnownHosts: |
+      github.com ssh-rsa AAAAB3NzaC1yc2E...
+    # Note: GIT_SYNC_SSH is no longer needed - auto-detected!
+```
+
+### Example 3: HTTP Auth with v4
+
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "https://github.com/your-org/private-dags.git"
+    ref: "v1.2.3"  # Tag
+    period: "30s"
+    # v4-change: Sync timeout now requires Go duration format
+    syncTimeout: "60s"
+    httpSecret: "airflow-git-http-secret"
+    httpSecretUsernameKey: username
+    httpSecretPasswordKey: token
+```
+
+### Example 4: Private Repo with Submodules
+
+```yaml
+dags:
+  gitSync:
+    enabled: true
+    image:
+      tag: v4.5.0
+    repo: "https://github.com/your-org/dags-with-submodules.git"
+    ref: "main"
+    depth: 0  # Full history for submodules
+    submodules: recursive
+    period: "2m"
+    # v4-change: Sync timeout now requires Go duration format
+    syncTimeout: "60s"
+    httpSecret: "git-credentials"
+    groupWrite: true
+```
+
+## Additional Resources
+
+- [git-sync v4 Official Migration Guide](https://github.com/kubernetes/git-sync/blob/master/v3-to-v4.md)
+- [git-sync GitHub Repository](https://github.com/kubernetes/git-sync)
+- [Chart Git-Sync Configuration Docs](../../README.md#dags)
+
+## Getting Help
+
+If you encounter issues during migration:
+
+1. Check the validation error messages for specific guidance
+2. Review the [git-sync v4 migration guide](https://github.com/kubernetes/git-sync/blob/master/v3-to-v4.md)
+3. Open an issue at [santosr2/airflow-community-chart](https://github.com/santosr2/airflow-community-chart/issues)

--- a/charts/airflow/examples/google-gke/custom-values.yaml
+++ b/charts/airflow/examples/google-gke/custom-values.yaml
@@ -313,6 +313,7 @@ dags:
 
   ## configs for the git-sync sidecar
   ## [FAQ] https://github.com/santosr2/airflow-community-chart/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
+  ## [NOTE] Chart supports both git-sync v3 and v4 - for v4 migration see: docs/guides/git-sync-v4-migration.md
   gitSync:
     enabled: true
 

--- a/charts/airflow/examples/minikube/custom-values.yaml
+++ b/charts/airflow/examples/minikube/custom-values.yaml
@@ -235,6 +235,7 @@ dags:
 
   ## configs for the git-sync sidecar
   ## [FAQ] https://github.com/santosr2/airflow-community-chart/blob/main/charts/airflow/docs/faq/dags/load-dag-definitions.md
+  ## [NOTE] Chart supports both git-sync v3 and v4 - for v4 migration see: docs/guides/git-sync-v4-migration.md
   gitSync:
     enabled: true
     repo: "https://github.com/USERNAME/REPOSITORY.git"

--- a/charts/airflow/templates/_helpers/validate-values.tpl
+++ b/charts/airflow/templates/_helpers/validate-values.tpl
@@ -571,3 +571,74 @@
   {{ required "For Airflow <3.0, use `ingress.web` instead of `ingress.apiServer`!" nil }}
   {{- end }}
 {{- end }}
+
+{{/* Checks for git-sync v4-specific values used with v3 */}}
+{{- if .Values.dags.gitSync.enabled }}
+{{- $gitSyncVersion := .Values.dags.gitSync.image.tag | trimPrefix "v" | splitList "." | first }}
+{{- $isV4 := ge (int $gitSyncVersion) 4 }}
+
+{{- if and (not $isV4) .Values.dags.gitSync.ref }}
+###############################################################################
+ERROR: git-sync v3 Configuration Error
+###############################################################################
+You have set `dags.gitSync.ref` but are using git-sync {{ .Values.dags.gitSync.image.tag }}.
+
+The `ref` value is only supported in git-sync v4+.
+
+Please either:
+  1. Update to git-sync v4: dags.gitSync.image.tag=v4.5.0
+  2. Use v3 values: dags.gitSync.branch and dags.gitSync.revision
+
+For more information, see: docs/guides/git-sync-v4-migration.md
+###############################################################################
+{{ required "git-sync v3 does not support the `ref` value!" nil }}
+{{- end }}
+
+{{- if and (not $isV4) .Values.dags.gitSync.period }}
+###############################################################################
+ERROR: git-sync v3 Configuration Error
+###############################################################################
+You have set `dags.gitSync.period` but are using git-sync {{ .Values.dags.gitSync.image.tag }}.
+
+The `period` value is only supported in git-sync v4+.
+
+Please either:
+  1. Update to git-sync v4: dags.gitSync.image.tag=v4.5.0
+  2. Use v3 value: dags.gitSync.syncWait
+
+For more information, see: docs/guides/git-sync-v4-migration.md
+###############################################################################
+{{ required "git-sync v3 does not support the `period` value!" nil }}
+{{- end }}
+
+{{- if and (not $isV4) .Values.dags.gitSync.groupWrite }}
+###############################################################################
+ERROR: git-sync v3 Configuration Error
+###############################################################################
+You have set `dags.gitSync.groupWrite=true` but are using git-sync {{ .Values.dags.gitSync.image.tag }}.
+
+The `groupWrite` value is only supported in git-sync v4+.
+
+Please update to git-sync v4: dags.gitSync.image.tag=v4.5.0
+
+For more information, see: docs/guides/git-sync-v4-migration.md
+###############################################################################
+{{ required "git-sync v3 does not support the `groupWrite` value!" nil }}
+{{- end }}
+
+{{- if and (not $isV4) .Values.dags.gitSync.gitConfig }}
+###############################################################################
+ERROR: git-sync v3 Configuration Error
+###############################################################################
+You have set `dags.gitSync.gitConfig` but are using git-sync {{ .Values.dags.gitSync.image.tag }}.
+
+The `gitConfig` value is only supported in git-sync v4+.
+
+Please update to git-sync v4: dags.gitSync.image.tag=v4.5.0
+
+For more information, see: docs/guides/git-sync-v4-migration.md
+###############################################################################
+{{ required "git-sync v3 does not support the `gitConfig` value!" nil }}
+{{- end }}
+
+{{- end }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -131,7 +131,7 @@ airflow:
   ## - [SECURITY] For production, store in external secret manager and reference via `airflow.extraEnv`
   ## - Generate a secure JWT secret:
   ##   python -c "import secrets; print(secrets.token_urlsafe(32))"
-  ## - Documentation: https://github.com/airflow-helm/charts/tree/main/charts/airflow/docs/faq/security/set-jwt-secret.md
+  ## - Documentation: https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/docs/faq/security/set-jwt-secret.md
   ##
   ## NOTE: Auto-generated secrets change on each `helm upgrade`, causing authentication failures
   ##       and restarts of all Airflow components until they pick up the new secret.
@@ -1987,6 +1987,8 @@ dags:
     size: 1Gi
 
   ## configs for the git-sync sidecar (https://github.com/kubernetes/git-sync)
+  ## - NOTE: v4+ is recommended for security updates and performance improvements
+  ## - for migration guide from v3 to v4, see: docs/guides/git-sync-v4-migration.md
   ##
   gitSync:
     ## if the git-sync sidecar container is enabled
@@ -1994,6 +1996,8 @@ dags:
     enabled: false
 
     ## the git-sync container image
+    ## - v3.x.x: uses GIT_SYNC_* environment variables
+    ## - v4.x.x: prefers GITSYNC_* but accepts GIT_SYNC_* for backward compatibility
     ##
     image:
       repository: registry.k8s.io/git-sync/git-sync
@@ -2027,22 +2031,41 @@ dags:
     repoSubPath: ""
 
     ## the git branch to check out
+    ## - NOTE: for git-sync v4+, consider using `ref` instead of `branch` + `revision`
     ##
     branch: master
 
     ## the git revision (tag or hash) to check out
+    ## - NOTE: for git-sync v4+, consider using `ref` instead of `branch` + `revision`
     ##
     revision: HEAD
 
+    ## the git ref to check out (branch, tag, or commit hash)
+    ## - NOTE: git-sync v4+ only
+    ## - when set, this overrides both `branch` and `revision` values
+    ## - examples: "main", "v1.0.0", "abc123def456..."
+    ##
+    ref: ""
+
     ## shallow clone with a history truncated to the specified number of commits
+    ## - NOTE: v4 defaults to 1 (single commit), set to 0 for full history
     ##
     depth: 1
 
     ## the number of seconds between syncs
+    ## - NOTE: deprecated in git-sync v4+, use `period` instead
     ##
     syncWait: 60
 
+    ## the period between syncs (git-sync v4 format)
+    ## - NOTE: git-sync v4+ only, uses Go duration format (e.g., "60s", "1m", "100ms")
+    ## - when set, this overrides `syncWait` value
+    ## - examples: "30s", "1m", "90s"
+    ##
+    period: ""
+
     ## the max number of seconds allowed for a complete sync
+    ## - NOTE: git-sync v4 must use Go duration format (e.g., "120s", "2m")
     ##
     syncTimeout: 120
 
@@ -2086,6 +2109,22 @@ dags:
     ##  - a value of -1 will retry forever after the initial sync
     ##
     maxFailures: 0
+
+    ## enable group-writable permissions on synced files (git-sync v4+)
+    ## - NOTE: git-sync v4+ only
+    ## - replaces the deprecated `--change-permissions` flag from v3
+    ## - when true, makes synced files group-writable
+    ##
+    groupWrite: false
+
+    ## additional git config options (git-sync v4+)
+    ## - NOTE: git-sync v4+ only
+    ## - format: "key1:value1,key2:value2"
+    ##
+    ## ____ EXAMPLE _______________
+    ##   gitConfig: "http.postBuffer:524288000,core.compression:0"
+    ##
+    gitConfig: ""
 
 ###################################
 ## CONFIG | Kubernetes Ingress
@@ -2380,7 +2419,7 @@ pgbouncer:
   ## configs for the pgbouncer container image
   ##
   image:
-    repository: ghcr.io/airflow-helm/pgbouncer
+    repository: ghcr.io/santosr2/pgbouncer
     tag: 1.22.1-patch.0
     pullPolicy: IfNotPresent
     uid: 1001
@@ -2584,7 +2623,7 @@ postgresql:
   ##
   image:
     registry: ghcr.io
-    repository: airflow-helm/postgresql-bitnami
+    repository: santosr2/postgresql-bitnami
     tag: 11.22-patch.0
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

- resolves https://github.com/santosr2/airflow-community-chart/issues/8


## What does your PR do?

This PR addresses:
- Support for git-sync v4
- Add validation for when using git-sync v4 parameters with git-sync v3
- Keep backward compatible
- Update pgbouncer and postgres image repository

Adds the following new values:
- `dags.gitSync.ref`
- `dags.gitSync.period`
- `dags.gitSync.groupWrite` (default: `false`)
- `dags.gitSync.gitConfig`


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [x] Documentation [updated](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated