### PR TITLE
fix: add missing git-sync key-file env var

### DIFF
--- a/charts/airflow/templates/_helpers/pods.tpl
+++ b/charts/airflow/templates/_helpers/pods.tpl
@@ -280,6 +280,12 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
     - name: GITSYNC_PERIOD
       value: {{ .Values.dags.gitSync.period | quote }}
     {{- end -}}
+    {{- /* SSH configuration (auto-detected in v4, explicit in v3) */ -}}
+    {{- if .Values.dags.gitSync.sshSecret }}
+    - name: GITSYNC_SSH_KEY_FILE
+      value: "/etc/git-secret/id_rsa"
+    {{- end -}}
+    {{- /* SSH known_hosts */}}
     {{- if .Values.dags.gitSync.sshKnownHosts }}
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "true"
@@ -289,6 +295,7 @@ EXAMPLE USAGE: {{ include "airflow.container.git_sync" (dict "Release" .Release 
     - name: GITSYNC_SSH_KNOWN_HOSTS
       value: "false"
     {{- end -}}
+    {{- /* HTTP authentication */ -}}
     {{- if .Values.dags.gitSync.httpSecret }}
     - name: GITSYNC_USERNAME
       valueFrom:


### PR DESCRIPTION
<!-- ⚠️ please review https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md -->


## What issues does your PR fix?

None


## What does your PR do?

Add the missing ssh key file git-sync environment variable


## Checklist

### For all Pull Requests

- [x] Commits are [signed off](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#sign-your-work)
- [x] Commits have [semantic messages](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#semantic-commit-messages)
- [ ] Documentation [updated](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#documentation)
- [x] Passes [ct linting](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#linting)

### For releasing ONLY

- [ ] Chart.yaml [version bumped](https://github.com/santosr2/airflow-community-chart/tree/main/charts/airflow/CONTRIBUTING.md#versioning)
- [ ] CHANGELOG.md updated